### PR TITLE
Repair style for reference.md

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -1,5 +1,4 @@
 ---
 layout: reference
-permalink: /reference/
 root: .
 ---


### PR DESCRIPTION
The Reference page for this lesson does not display according to the Carpentries style and contains a hard coded subdirectory that makes the header links fail. Attempting to fix per @weaverbel fix on LibraryCarpentry/lc-data-intro#49