### PR TITLE
Update handout reference link

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -10,7 +10,7 @@ ____
 ____
 ## Making a handout
 
-Librarians like handouts. To make a handout for this lesson, adapt/print from [https://librarycarpentry.github.io/lc-open-refine/reference/](https://librarycarpentry.github.io/lc-open-refine/reference/).
+Librarians like handouts. To make a handout for this lesson, adapt/print from [https://librarycarpentry.github.io/lc-open-refine/reference.html](https://librarycarpentry.github.io/lc-open-refine/reference.html).
 
 ____
 # General notes on OpenRefine


### PR DESCRIPTION
Update handout reference link to:
https://librarycarpentry.github.io/lc-open-refine/reference.html

