### PR TITLE
Space between brackets

### DIFF
--- a/_episodes/13-looking-up-data.md
+++ b/_episodes/13-looking-up-data.md
@@ -71,7 +71,7 @@ The next exercise demonstrates this two stage process in full.
 {: .challenge}
 
 ## Reconciliation services
-Reconciliation services allow you to lookup terms from your data in OpenRefine against external services, and use values from the external services in your data. The official wiki provides [detailed information about this feature] (https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation).
+Reconciliation services allow you to lookup terms from your data in OpenRefine against external services, and use values from the external services in your data. The official wiki provides [detailed information about this feature](https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation).
 
 Reconciliation services can be more sophisticated and often quicker than using the method described above to retrieve data from a URL. However, to use the ‘Reconciliation’ function in OpenRefine requires the external resource to support the necessary service for OpenRefine to work with, which means unless the service you wish to use supports such a service you cannot use the ‘Reconciliation’ approach.
 


### PR DESCRIPTION
I was working through the tutorial and noticed that there was a space between the brackets stopping the link from activating
