### PR TITLE
Update 06-working-with-columns.md

### DIFF
--- a/_episodes/06-working-with-columns.md
+++ b/_episodes/06-working-with-columns.md
@@ -15,12 +15,12 @@ keypoints:
 ---
 
 ## Reordering and renaming columns
-You can re-order the columns by clicking the drop-down menu at the top of the first column (labelled 'All'), and choosing `Edit columns->Re-order / remove columns …`
+You can re-order the columns by clicking the drop-down menu at the top of the first column (labelled 'All') and choosing `Edit columns->Re-order / remove columns …`
 
-You can then drag and drop column names to re-order the columns, or remove columns completely if they are not required.
+You can then drag and drop column names to re-order the columns or remove columns completely if they are not required.
 
 ## Sorting data
-You can sort data in OpenRefine by clicking on the drop-down menu for the column you want to sort on, and choosing `Sort`.
+You can sort data in OpenRefine by clicking on the drop-down menu for the column you want to sort on and choosing `Sort`.
 
 Once you have sorted the data, a new `Sort` drop-down menu will be displayed.
 


### PR DESCRIPTION
Unnecessary commas before 'and' and 'or'.  Chicago Manual of Style says to avoid these.

Stephen Cox


