### PR TITLE
Add note for Windows users to keep terminal open

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -29,7 +29,7 @@ To run Refine:
 * On Linux: Navigate to the folder where you’ve installed OpenRefine in a terminal window and type ‘./refine’
 * On Mac: Navigate to where you installed OpenRefine and click the OpenRefine icon
 
-The interface to OpenRefine is accessed via a web browser. When you run Refine normally this should open a window in your default web browser pointing at the address http://127.0.0.1:3333. If this doesn't happen automatically you can open a web browser and type in this address.
+The interface to OpenRefine is accessed via a web browser. When you run Refine normally this should open a window in your default web browser pointing at the address http://127.0.0.1:3333.  If this doesn't happen automatically you can open a web browser and type in this address. Note, on Windows, a terminal window will appear when you run OpenRefine. Keep this open so that OpenRefine continues to run.
 
 ### Getting Help
 


### PR DESCRIPTION
Add:
"Note, on Windows, a terminal window will appear when you run OpenRefine. Keep this open so that OpenRefine continues to run."