### PR TITLE
bring prerequisites and setup into line

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,6 @@ layout: lesson
 This Library Carpentry lesson introduces people working in library- and information-related roles to working with data in OpenRefine. At the conclusion of the lesson you will understand what the OpenRefine software does and how to use the OpenRefine software to work with data files.
 
 > ## Prerequisites
->To complete this lesson you will need Firefox web browser and OpenRefine. 
-> If not already installed, you will need to install [Firefox](https://www.mozilla.org/en-US/firefox/new/)
-> and [OpenRefine](http://openrefine.org/download.html). See [Setup](https://librarycarpentry.org/lc-open-refine/setup.html) for more information.
+> To complete this lesson you will need to install [OpenRefine](http://openrefine.org/download.html) and download the file [doaj-article-sample.csv](https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv).
+> See [Setup](https://librarycarpentry.org/lc-open-refine/setup.html) for more information.
 {: .prereq}

--- a/index.md
+++ b/index.md
@@ -5,5 +5,6 @@ This Library Carpentry lesson introduces people working in library- and informat
 
 > ## Prerequisites
 > To complete this lesson you will need to install [OpenRefine](http://openrefine.org/download.html) and download the file [doaj-article-sample.csv](https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv).
+> OpenRefine does not support Internet Explorer or Edge. Please use [Firefox](https://www.mozilla.org/firefox/new/), [Chrome](https://www.google.com/chrome/) or [Safari](https://www.apple.com/safari/) instead.
 > See [Setup](https://librarycarpentry.org/lc-open-refine/setup.html) for more information.
 {: .prereq}

--- a/setup.md
+++ b/setup.md
@@ -18,8 +18,9 @@ There are versions for Windows, Mac OS X and Linux.
 Please follow the installation instructions on the OpenRefine wiki: [Installation Instructions](https://github.com/OpenRefine/OpenRefine/wiki/Installation-Instructions)
 
 Notes:
+* When you download OpenRefine for Windows or Linux from the address above, you are downloading a zip file. To install OpenRefine you simply unzip the downloaded file wherever you want to install the program. This can be to a personal directory or to an applications or software directory - OpenRefine should run wherever you put the unzipped folder. The location has to be a "local" drive as problems have been reported trying to run OpenRefine from a Network drive.
 * OpenRefine is a Java application, and you need to have a 'Java Runtime Environment' (JRE) installed on your computer to run OpenRefine. If you don’t already have one installed then you can download and install from [http://java.com](http://java.com) by going to the site and clicking "Free Java Download".
-* OpenRefine does not support Internet Explorer. Please use [Firefox](https://www.mozilla.org/firefox/new/), [Chrome](https://www.google.com/chrome/) or [Safari](https://www.apple.com/safari/) instead.
+* OpenRefine does not support Internet Explorer or Edge. Please use [Firefox](https://www.mozilla.org/firefox/new/), [Chrome](https://www.google.com/chrome/) or [Safari](https://www.apple.com/safari/) instead.
 
 ### Downloading the data
 

--- a/setup.md
+++ b/setup.md
@@ -5,33 +5,27 @@ title: Setup
 
 ## Getting ready
 
-You need to download and install OpenRefine and download a data file to follow this lesson.
+You need to install OpenRefine and download a data file to follow this lesson.
 
-### Downloading OpenRefine
+### Installing and running OpenRefine
 
-You can download OpenRefine from [http://openrefine.org/download.html](http://openrefine.org/download.html). This lesson has been tested with all versions of OpenRefine up to the latest tested version, 3.1.  
+You can download OpenRefine from [http://openrefine.org/download.html](http://openrefine.org/download.html). This lesson has been tested with all versions of OpenRefine up to the latest tested version, 3.1.
 
 If you are using an older version, it is recommended you upgrade to the latest tested version. 
 
 There are versions for Windows, Mac OS X and Linux.
 
-### Installing and Running OpenRefine
+Please follow the installation instructions on the OpenRefine wiki: [Installation Instructions](https://github.com/OpenRefine/OpenRefine/wiki/Installation-Instructions)
 
-When you download OpenRefine for Windows or Linux from the address above, you are downloading a zip file. To install OpenRefine you simply unzip the downloaded file wherever you want to install the program. This can be to a personal directory or to an applications or software directory - OpenRefine should run wherever you put the unzipped folder. The location has to be a "local" drive as problems have been reported trying to run OpenRefine from a Network drive.
+Notes:
+* OpenRefine is a Java application, and you need to have a 'Java Runtime Environment' (JRE) installed on your computer to run OpenRefine. If you don’t already have one installed then you can download and install from [http://java.com](http://java.com) by going to the site and clicking "Free Java Download".
+* OpenRefine does not support Internet Explorer. Please use [Firefox](https://www.mozilla.org/firefox/new/), [Chrome](https://www.google.com/chrome/) or [Safari](https://www.apple.com/safari/) instead.
 
-If you are downloading OpenRefine for Mac, you are downloading a 'dmg' (disk image) file which you can open, and then drag the OpenRefine application to an appropriate folder on you computer.
+### Downloading the data
 
-**OpenRefine is a Java application, and you need to have a 'Java Runtime Environment' (JRE) installed on your computer to run OpenRefine**. If you don’t already have one installed then you can download and install from [http://java.com](http://java.com) by going to the site and clicking "Free Java Download".
+You can download [doaj-article-sample.csv](https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv), which is a csv file that will open in a new browser tab. Be sure to right click or control click in order to save the file (NOTE: In Safari, right click and select **download linked file**; in Chrome and Firefox, right click and select **save link as**). Make a note of the location (i.e the folder, your desktop) to which you save the file.
 
-To run Refine:
-
-* On Windows: Navigate to the folder where you’ve installed OpenRefine and double-click ‘openrefine.exe’
-* On Linux: Navigate to the folder where you’ve installed OpenRefine in a terminal window and type ‘./refine’
-* On Mac: Navigate to where you installed OpenRefine and click the OpenRefine icon
-
-The interface to OpenRefine is accessed via a web browser. When you run Refine normally this should open a window in your default web browser pointing at the address http://127.0.0.1:3333.  If this doesn't happen automatically you can open a web browser and type in this address. Note, on Windows, a terminal window will appear when you run OpenRefine. Keep this open so that OpenRefine continues to run.
-
-### Getting Help
+### Getting help
 
 If you encounter problems installing or running OpenRefine, a good source of support is [the OpenRefine mailing list and forum](https://groups.google.com/forum/?fromgroups#!forum/openrefine).
 
@@ -47,14 +41,5 @@ There are also general and specialist tutorials about using OpenRefine available
 * [Data Munging Tools in Preparation for RDF: Catmandu and LODRefine by Christina Harlow](http://journal.code4lib.org/articles/11013)
 * [Cleaning Data with OpenRefine by John Little](https://libjohn.github.io/openrefine/)
 * [OpenRefine Blog](http://openrefine.org/category/edge-case.html)
-
-### Downloading the data
-
-There are a number of ways to get the data we will be using in OpenRefine.
-
-1. Once you have started OpenRefine, use this link [https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv](https://raw.githubusercontent.com/LibraryCarpentry/lc-open-refine/gh-pages/data/doaj-article-sample.csv) to import the data directly into OpenRefine using the **Web Addresses URLs** option.
-
-2. You can download [doaj-article-sample.csv](https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv), which is a csv file that will open in a new browser tab. Be sure to right click or control click in order to save the file (NOTE: In Safari, right click and select **download linked file**; in Chrome and Firefox, right click and select **save link as**). Make a note of the location (i.e the folder, your desktop) to which you save the file.
-
 
 [template]: {{ site.workshop_repo }}


### PR DESCRIPTION
I stumbled upon the different instructions in the prerequisites box (index.md) and the setup page (setup.md). I wonder if there is a reason why the Firefox browser is mentioned? OpenRefine does not support Internet Explorer but Chrome or Safari are suitable too. I'd even say that the browser isn't crucial here (even though I love Firefox). For the impatient, I'd rather give the link to the file download instead. I suggest to add a note regarding the browser support in the setup page.

Having a closer look on the setup page I would like to suggest some more changes:
* In the meantime the OpenRefine wiki contains detailed installation instructions. Maybe it's better to link there and shorten the instructions?
* There are two main tasks for setup: 1. install OpenRefine and 2. download the data. Perhaps it's easier to grasp the main tasks when downloading, installing and running OpenRefine are combined into one chapter and when the chapter downloading the data is moved up?
* Providing two options for downloading the data makes things complicated. The exercise in chapter 2 (importing data into OpenRefine) gives detailed instructions based on the file download. I propose to delete the `Web Addresses URLs` option (or move this option to chapter 2).