### PR TITLE
Correct date transformation to ISO 8601

### DIFF
--- a/_episodes/10-data-transformation.md
+++ b/_episodes/10-data-transformation.md
@@ -31,7 +31,8 @@ So far we've been looking only at 'String' type data. Much of the time it is pos
 
 >## Reformat the Date
 >1. Make sure you remove all Facets and Filters
->2. On the Date column use the dropdown menu to select ```Edit cells->Common transforms->To date```
+>2. On the Date column use the dropdown menu to select ```Edit cells -> Transform```
+>2. In the 'Expression' box type the GREL expression ```value.toDate("dd/MM/yyyy")``` and press OK.
 >3. Note how the values are now displayed in green and follow a standard convention for their display format (ISO 8601) - this indicates they are now stored as date data types in OpenRefine. We can now carry out functions that are specific to Dates
 >4. On the Date column dropdown select ```Edit column->Add column based on this column```. Using this function you can create a new column, while preserving the old column
 >5. In the 'New column name' type "Formatted Date"


### PR DESCRIPTION
See #106. I'm not sure whether the Carpentries style will correctly count through the duplicate `2.` and can't test it right now.

If it doesn't, please feel free to add commits to my branch that merge the two items into a single `2.` line or renumber the entire block, or whatever you find best