### PR TITLE
Update 07-introduction-to-transformations.md

### DIFF
--- a/_episodes/07-introduction-to-transformations.md
+++ b/_episodes/07-introduction-to-transformations.md
@@ -7,8 +7,8 @@ questions:
 - "What are the kind of transformations Open Refine supports?"
 - "What is GREL?"
 objectives:
-- "Introduce common transformations"
-- "Introduce GREL, the General Refine Expression Language"
+- "Describe common transformations"
+- "Explain GREL, the General Refine Expression Language"
 keypoints:
 - "Common transformations are available through the Menu option"
 ---


### PR DESCRIPTION
Changed the wording of the episode objectives to be more in line with Bloom's taxonomy. "Introduce" was replaced with "Describe" and "Explain". 

