### PR TITLE
changes to objectives for the lesson to student outcomes

### DIFF
--- a/_episodes/03-working-with-data.md
+++ b/_episodes/03-working-with-data.md
@@ -11,6 +11,13 @@ objectives:
 - Locate controls for navigating data in OpenRefine
 - Find options to work with data through the OpenRefine dropdown menus
 - Split cells which contain multiple bits of data so that each piece of data is in its own cell
+
+Student outcomes
+After this lesson you will be able to:
+- Split and join multi value cells using an appropriate seperator.
+- Describe how rows and record differ in OpenRefine
+
+
 keypoints:
 - "OpenRefine uses rows and columns to display data"
 - "Most options to work with data in OpenRefine are accessed through a drop down menu at the top of a data column"


### PR DESCRIPTION
Edit as part of instructor checkout. With online materials where a student may return to refresh themselves at any point its good to make the key learning outcomes for the student rather than objectives. This will mean more to the student when they return and also reduce the number of objectives as objectives often end up as a long list of each thing covered, As a guide write 'what will the student be able to do after this lesson they couldn't before?'