### PR TITLE
[translations] Clean lessons to create po files

### DIFF
--- a/_episodes/02-importing-data.md
+++ b/_episodes/02-importing-data.md
@@ -39,7 +39,6 @@ keypoints:
 >8. Once you are happy click the `Create Project >>` button at the top right of the screen. This will create the project and open it for you. Projects are saved as you work on them, there is no need to save copies as you go along.
 >   
 > ![Create project screen capture](../assets/img/openrefine_ui.png)
->
 {: .checklist}
 
 To open an existing project in OpenRefine you can click `Open Project` from the main OpenRefine screen (in the left hand menu). When you click this, you will see a list of the existing projects and can click on a project's name to open it.

--- a/_episodes/03-working-with-data.md
+++ b/_episodes/03-working-with-data.md
@@ -110,7 +110,6 @@ Splitting on a comma will not work with Authors because the names may include co
 > When creating a spreadsheet with multi-valued cells, it is important to choose a separator that will never appear in
 > the cell values themselves. For this reason, the pipe character ( \| ) is often a good choice since it
 > is rarely used in data. Commas, colons and semi-colons should be avoided as separators.
->
 {: .callout}
 
 >## Splitting Subjects into separate cells


### PR DESCRIPTION
The `po` files are the tokenised version of the lessons. The [tool we are using](https://github.com/carpentries-i18n/po4gitbook) complains if the following *typos* or empty lines at the end of sections are not fixed.