### PR TITLE
Add a dash to Formatted Date column

### DIFF
--- a/_episodes/10-data-transformation.md
+++ b/_episodes/10-data-transformation.md
@@ -35,7 +35,7 @@ So far we've been looking only at 'String' type data. Much of the time it is pos
 >2. In the 'Expression' box type the GREL expression ```value.toDate("dd/MM/yyyy")``` and press OK.
 >3. Note how the values are now displayed in green and follow a standard convention for their display format (ISO 8601) - this indicates they are now stored as date data types in OpenRefine. We can now carry out functions that are specific to Dates
 >4. On the Date column dropdown select ```Edit column->Add column based on this column```. Using this function you can create a new column, while preserving the old column
->5. In the 'New column name' type "Formatted Date"
+>5. In the 'New column name' type "Formatted-Date"
 >6. In the 'Expression' box type the GREL expression ```value.toString("dd MMMM yyyy")```
 {: .checklist}
 


### PR DESCRIPTION
When we create this column, we should use dash, underscore, or CamelCase conventions when creating this column name to reflect what we teach learners about about in the Tidy Data lesson.  This is something I already do when teaching this lesson, but it should probably actually be in the lesson.




