### PR TITLE
Add a dash to Journal Details column name

### DIFF
--- a/_episodes/13-looking-up-data.md
+++ b/_episodes/13-looking-up-data.md
@@ -46,7 +46,7 @@ The next exercise demonstrates this two stage process in full.
 >    * Facet by Star
 >    * Choose the single row
 >* In the ISSN column use the dropdown menu to choose 'Edit column->Add column by fetching URLs'
->* Give the column a name e.g. "Journal details"
+>* Give the column a name e.g. "Journal-Details"
 >* In the expression box you need to write some GREL where the output of the expression is a URL which can be used to retrieve data (the format of the data could be HTML, XML, JSON, or some other text format)
 >
 >In this case we are going to use the CrossRef API: [https://github.com/CrossRef/rest-api-doc)](https://github.com/CrossRef/rest-api-doc). Read more about the CrossRef service: [http://www.crossref.org](http://www.crossref.org). Note that API providers may impose rate limits or have other requirements for using their data, so it's important to check the site's documentation. To comply with API rate limits, use the Throttle Delay setting to specify the number of milliseconds between URL requests. CrossRef, for instance, [asks users](https://github.com/CrossRef/rest-api-doc#etiquette) to "specify a User-Agent header that properly identifies your script or tool and that provides a means of contacting you via email using 'mailto:'." User-agent headers provide administrators with user information that facilitates better administration and moderation of the API, and it is generally good etiquette to include a header with any API request.


### PR DESCRIPTION
When we create this column, we should use dash, underscore, or CamelCase conventions when creating this column name to reflect what we teach learners about about in the Tidy Data lesson. This is something I already do when I teach the lesson, but it should probably be an actual part of the lesson.

