### PR TITLE
Add dash to VIAF ID column name

### DIFF
--- a/_episodes/13-looking-up-data.md
+++ b/_episodes/13-looking-up-data.md
@@ -138,7 +138,7 @@ For more information on using Reconciliation services see [https://github.com/Op
 >There are two things that reconciliation can do for you. Firstly it gets a standard form of the name or label for the entity. Secondly it gets an ID for the entity - in this case a VIAF id. This is hidden in the default view, but can be extracted:
 >
 >* In the Publisher column use the dropdown menu to choose 'Edit column->Add column based on this column...'
->* Give the column the name 'VIAF ID'
+>* Give the column the name 'VIAF-ID'
 >* In the GREL expression box type ```cell.recon.match.id```
 >* This will create a new column that contains the VIAF ID for the matched entity
 {: .challenge}


### PR DESCRIPTION
When we create this column, we should use dash, underscore, or CamelCase conventions when creating this column name to reflect what we teach learners about about in the Tidy Data lesson. This is something I already do when I teach the lesson, but it should probably be an actual part of the lesson.

