### PR TITLE
update openrefineder to 3.4

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -36,5 +36,4 @@ ____
   - Run openrefine.exe
 
 * If a learner is unable to install OpenRefine on their computer due to IT restrictions for example, there are cloud services available that they could try:
-  - [openrefineder](https://github.com/betatim/openrefineder/) using MyBinder [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/077bbff?urlpath=%2Fopenrefine) (OpenRefine 3.1, free to use without registration, [restricted](https://mybinder.readthedocs.io/en/latest/faq.html#how-much-memory-am-i-given-when-using-binder) to 1-2 GB RAM and server will be deleted after 10 minutes of inactivity)
-  - [openrefineder](https://github.com/betatim/openrefineder/) using MyBinder [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/79aeff9?urlpath=%2Fopenrefine) (OpenRefine 3.2, same restrictions as above)
+  - [openrefineder](https://github.com/betatim/openrefineder/) using MyBinder [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/6ba108b?urlpath=%2Fopenrefine) (OpenRefine 3.4.1, free to use without registration, [restricted](https://mybinder.readthedocs.io/en/latest/faq.html#how-much-memory-am-i-given-when-using-binder) to 1-2 GB RAM and server will be deleted after 10 minutes of inactivity)


### PR DESCRIPTION
Because the lesson was successfully tested with OpenRefine 3.4, the link to start openrefineder in the instructors notes should also be updated to the current OpenRefine version.