### PR TITLE
Doc links update

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -68,5 +68,5 @@ Some common scenarios might be:
 ## What Should I Know When Working With OpenRefine?
 * No internet connection is needed, and none of the data or commands you enter in OpenRefine are sent to a remote server.
 * You are NOT modifying original/raw data.
-* Saving will happen automatically, but it's important to [properly shut down OpenRefine to ensure this](https://github.com/OpenRefine/OpenRefine/wiki/Installation-Instructions).
+* Projects are autosaved every five minutes and when OpenRefine is properly shut down (Ctrl+C). See [History in User Manual](https://docs.openrefine.org/manual/running/#history-undoredo) for details.
 * Files are saved locally such that if you are working on two computers you will have to export/import files/projects.

--- a/_episodes/07-introduction-to-transformations.md
+++ b/_episodes/07-introduction-to-transformations.md
@@ -25,7 +25,7 @@ However, sometimes there will be changes you want to make to the data that canno
 
 To support this type of activity OpenRefine supports 'Transformations' which are ways of manipulating data in columns. Transformations are normally written in a special language called 'GREL' (General Refine Expression Language). To some extent GREL expressions are similar to Excel Formula, although they tend to focus on text manipulations rather than numeric functions.
 
-Full documentation for the GREL is available at [https://github.com/OpenRefine/OpenRefine/wiki/General-Refine-Expression-Language](https://github.com/OpenRefine/OpenRefine/wiki/General-Refine-Expression-Language). This tutorial covers only a small subset of the commands available.
+Full documentation for the GREL is available at [https://docs.openrefine.org/manual/grelfunctions](https://docs.openrefine.org/manual/grelfunctions). This tutorial covers only a small subset of the commands available.
 
 ### Common transformations
 Some transformations are used regularly and are accessible directly through menu options, without having to type them directly.

--- a/_episodes/13-looking-up-data.md
+++ b/_episodes/13-looking-up-data.md
@@ -64,7 +64,7 @@ The next exercise demonstrates this two stage process in full.
 >
 >At this point you should have a new cell containing a long text string in a format called 'JSON' (this stands for JavaScript Object Notation, although very rarely spelt out in full).
 >
->OpenRefine has a function for extracting data from JSON (sometimes referred to as 'parsing' the JSON). The 'parseJson' function is explained in more detail at [https://github.com/OpenRefine/OpenRefine/wiki/GREL-Other-Functions](https://github.com/OpenRefine/OpenRefine/wiki/GREL-Other-Functions).
+>OpenRefine has a function for extracting data from JSON (sometimes referred to as 'parsing' the JSON). The 'parseJson' function is explained in more detail at [https://docs.openrefine.org/manual/grelfunctions/#format-based-functions-json-html-xml](https://docs.openrefine.org/manual/grelfunctions/#format-based-functions-json-html-xml).
 >
 >* In the new column you've just added use the dropdown menu to access 'Edit column->Add column based on this column'
 >* Add a name for the new column e.g. "Journal-Title"
@@ -75,7 +75,7 @@ The next exercise demonstrates this two stage process in full.
 {: .challenge}
 
 ## Reconciliation services
-Reconciliation services allow you to lookup terms from your data in OpenRefine against external services, and use values from the external services in your data. The official wiki provides [detailed information about this feature](https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation).
+Reconciliation services allow you to lookup terms from your data in OpenRefine against external services, and use values from the external services in your data. The official User Manual provides [detailed information about this reconciling](https://docs.openrefine.org/manual/reconciling).
 
 Reconciliation services can be more sophisticated and often quicker than using the method described above to retrieve data from a URL. However, to use the ‘Reconciliation’ function in OpenRefine requires the external resource to support the necessary service for OpenRefine to work with, which means unless the service you wish to use supports such a service you cannot use the ‘Reconciliation’ approach.
 

--- a/_episodes/13-looking-up-data.md
+++ b/_episodes/13-looking-up-data.md
@@ -75,7 +75,7 @@ The next exercise demonstrates this two stage process in full.
 {: .challenge}
 
 ## Reconciliation services
-Reconciliation services allow you to lookup terms from your data in OpenRefine against external services, and use values from the external services in your data. The official User Manual provides [detailed information about this reconciling](https://docs.openrefine.org/manual/reconciling).
+Reconciliation services allow you to lookup terms from your data in OpenRefine against external services, and use values from the external services in your data. The official User Manual provides [detailed information about this feature](https://docs.openrefine.org/manual/reconciling).
 
 Reconciliation services can be more sophisticated and often quicker than using the method described above to retrieve data from a URL. However, to use the ‘Reconciliation’ function in OpenRefine requires the external resource to support the necessary service for OpenRefine to work with, which means unless the service you wish to use supports such a service you cannot use the ‘Reconciliation’ approach.
 

--- a/files/draft-instructor-notes.md
+++ b/files/draft-instructor-notes.md
@@ -206,7 +206,7 @@ Share your recipes on GitHub
 Things to note:
 
 Allocate more memory:
-https://github.com/OpenRefine/OpenRefine/wiki/FAQ%3A-Allocate-More-Memory
+https://docs.openrefine.org/manual/installing/#increasing-memory-allocation
 
 
 Extra:

--- a/setup.md
+++ b/setup.md
@@ -9,13 +9,13 @@ You need to install OpenRefine and download a data file to follow this lesson.
 
 ### Installing and running OpenRefine
 
-You can download OpenRefine from [http://openrefine.org/download.html](http://openrefine.org/download.html). This lesson has been tested with all versions of OpenRefine up to the latest tested version, 3.4.
+You can download OpenRefine from [https://openrefine.org/download.html](https://openrefine.org/download.html). This lesson has been tested with all versions of OpenRefine up to the latest tested version, 3.4.
 
 If you are using an older version, it is recommended you upgrade to the latest tested version. 
 
 There are versions for Windows, macOS and Linux.
 
-Please follow the installation instructions on the OpenRefine wiki: [Installation Instructions](https://github.com/OpenRefine/OpenRefine/wiki/Installation-Instructions)
+Please follow the installation instructions in the OpenRefine User Manual: [Installation Instructions](https://docs.openrefine.org/manual/installing)
 
 Notes:
 * When you download OpenRefine for Windows or Linux from the address above, you are downloading a zip file. To install OpenRefine you unzip the downloaded file wherever you want to install the program. This can be to a personal directory or to an applications or software directory - OpenRefine should run wherever you put the unzipped folder. The location has to be a "local" drive as problems have been reported trying to run OpenRefine from a Network drive.
@@ -28,7 +28,7 @@ You can download [doaj-article-sample.csv](https://github.com/LibraryCarpentry/l
 
 ### Getting help
 
-If you encounter problems installing or running OpenRefine, a good source of support is [the OpenRefine mailing list and forum](https://groups.google.com/forum/?fromgroups#!forum/openrefine).
+If you encounter problems installing or running OpenRefine, a good source of support is [the OpenRefine mailing list and forum](https://groups.google.com/g/openrefine).
 
 If you are installing OpenRefine on Windows, you may want to check the forum for ['Windows' related threads](https://groups.google.com/forum/?fromgroups#!searchin/openrefine/windows%7Csort:date) or specific threads like [Installing OpenRefine on Windows 7](https://groups.google.com/forum/?fromgroups#!searchin/openrefine/64-bit%7Csort:date/openrefine/vUzqJqJ-sAA/Tb2Om9wvaqgJ).
 


### PR DESCRIPTION
This PR updates links to OpenRefine reference from the old Wiki to the new docs "User Manual" site, https://docs.openrefine.org/

Refine is phasing out the wiki, so the User Manual should be the preferred reference. It slightly changes wording in link text to reflect the update.