### PR TITLE
Updating list of browsers to use

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,14 @@ This Library Carpentry lesson introduces people working in library- and informat
 
 > ## Prerequisites
 > To complete this lesson you will need to install [OpenRefine](http://openrefine.org/download.html) and download the file [doaj-article-sample.csv](https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv).
-> OpenRefine does not support Internet Explorer or Edge. Please use [Firefox](https://www.mozilla.org/firefox/new/), [Chrome](https://www.google.com/chrome/) or [Safari](https://www.apple.com/safari/) instead.
+>
+> OpenRefine requires one of these web browsers:
+> * Google Chrome
+> * Chromium
+> * Opera
+> * Microsoft Edge
+> 
+> OpenRefine has some issues with Firefox. Internet Explorer is not supported. 
+> 
 > See [Setup](https://librarycarpentry.org/lc-open-refine/setup.html) for more information.
 {: .prereq}


### PR DESCRIPTION
Copying the list of browsers from the OpenRefine instructions and making clear that Edge can be used while Firefox and IE should be avoided.