### PR TITLE
Remove or replace 'simply', 'just', 'easily' from episodes 4, 5, 8, 9, 10, 13

### DIFF
--- a/_episodes/04-faceting-and-filtering.md
+++ b/_episodes/04-faceting-and-filtering.md
@@ -6,7 +6,7 @@ questions:
 - "What is a facet in OpenRefine?"
 - "What is a filter in OpenRefine?"
 - "How can I use filters and facets to explore data in OpenRefine?"
-- "How can I easily correct common data issues in my data with OpenRefine?"
+- "How can I correct common data issues in my data with OpenRefine?"
 objectives:
 - "Explain what Facets and Filters are"
 - "Answer questions about the content of a data set using Facets"
@@ -15,7 +15,7 @@ objectives:
 keypoints:
 - "You can use facets and filters to explore your data"
 - "You can use facets and filters work with a subset of data in OpenRefine"
-- "You can easily correct common data issues from a Facet"
+- "You can correct common data issues from a Facet"
 ---
 
 ## Facets
@@ -23,7 +23,7 @@ Facets are one of the most useful features of OpenRefine and can help in both ge
 
 A 'Facet' groups all the values that appear in a column, and then allows you to filter the data by these values and edit values across many records at the same time.
 
-The simplest type of Facet is called a 'Text facet'. This simply groups all the text values in a column and lists each value with the number of records it appears in. The facet information always appears in the left hand panel in the OpenRefine interface.
+The simplest type of Facet is called a 'Text facet'. This groups all the text values in a column and lists each value with the number of records it appears in. The facet information always appears in the left hand panel in the OpenRefine interface.
 
 To create a Text Facet for a column, click on the drop down menu at the top of the publisher column and choose `Facet -> Text Facet`. The facet will then appear in the left hand panel.
 
@@ -31,11 +31,11 @@ The facet consists of a list of values used in the data. You can filter the data
 
 You can include multiple values from the facet in a filter at one time by using the `Include` option which appears when you put your mouse over a value in the Facet.
 
-You can also `invert` the filter to show all records which do not match your selected values. This option appears at the top of the Facet panel when you select a value from the facet to apply as a filter.
+You can also `invert` the facet to show all records which do not match your selected values. This option appears at the top of the Facet panel when you select a value from the facet to apply as a filter.
 
 >## Let's create a text facet
 >1. Click on the drop down menu at the top of the publisher column and choose `Facet > Text Facet`. The facet will then appear in the left hand panel
->2. To select a single value, just click the relevant line in the facet
+>2. To select a single value, click the text of the relevant line in the facet
 >3. To select multiple values click the `Include` option on the appropriate line in the facet (which only appears when you mouse over the line)
 >3. You can 'invert' your selections to `exclude`
 >4. Include a value and then look at top to invert inclusion.
@@ -58,15 +58,15 @@ You can also `invert` the filter to show all records which do not match your sel
 ## Filters
 As well as using Facets to filter the data displayed in OpenRefine you can also apply 'Text Filters' which looks for a particular piece of text appearing in a column  based on a unique text string, like a 'find' feature. Text filters are applied by clicking the drop down menu at the top of the column you want to apply the filter to and choosing 'Text filter'.
 
-As with Facets, the Filter options appear in the left hand panel in OpenRefine. Simply type in the text you want to use in the Filter to display only rows which contain that text in the relevant column.
+As with Facets, the Filter options appear in the left hand panel in OpenRefine. As you type the text you want to find into the Filter's text box, OpenRefine works to display only rows that contain that text in the relevant column.
 
 You can also use [regular expressions](https://librarycarpentry.github.io/lc-data-intro/01-regular-expressions/) in the filter.
 
 ## Working with filtered data
-It is very important to note that when you have filtered the data displayed in OpenRefine, any operations you carry out will apply only to the rows that match the filter - that is the data currently being displayed. To confirm you are working with the data you intended to select, check the number of matching records displayed above the data table. 
+It is very important to note that when you have filtered the data displayed in OpenRefine, any operations you carry out will apply only to the rows that match the filter - that is the data currently being displayed. To confirm you are working with the data you intended to select, check the number of matching records displayed above the data table.
 
-## Other types of Facet 
-As well as 'Text facets' Refine also supports a range of other types of facet. These include:
+## Other types of Facet
+As well as 'Text facets' OpenRefine also supports a range of other types of facet. These include:
 
 * Numeric facets
 * Timeline facets (for dates)
@@ -99,7 +99,7 @@ Facets are intended to group together common values and OpenRefine limits the nu
 {: .challenge}
 
 ## Amending data through facets
-If you create a text facet you can edit the values in the facet to change the value for several records at the same time. To do this, simply mouse-over the value you want to edit and click the 'edit' option that appears.
+If you create a text facet you can edit the values in the facet to change the value for several records at the same time. To do this, mouse-over the value you want to edit and click the 'edit' option that appears.
 
 This approach is useful in relatively small facets where you might have small variations through punctuation or typing errors etc. For example, a column that should contain only terms from a small restricted list such as days of the week or months of the year.
 

--- a/_episodes/04-faceting-and-filtering.md
+++ b/_episodes/04-faceting-and-filtering.md
@@ -31,7 +31,7 @@ The facet consists of a list of values used in the data. You can filter the data
 
 You can include multiple values from the facet in a filter at one time by using the `Include` option which appears when you put your mouse over a value in the Facet.
 
-You can also `invert` the facet to show all records which do not match your selected values. This option appears at the top of the Facet panel when you select a value from the facet to apply as a filter.
+You can also `invert` the filter to show all records which do not match your selected values. This option appears at the top of the Facet panel when you select a value from the facet to apply as a filter.
 
 >## Let's create a text facet
 >1. Click on the drop down menu at the top of the publisher column and choose `Facet > Text Facet`. The facet will then appear in the left hand panel
@@ -58,7 +58,7 @@ You can also `invert` the facet to show all records which do not match your sele
 ## Filters
 As well as using Facets to filter the data displayed in OpenRefine you can also apply 'Text Filters' which looks for a particular piece of text appearing in a column  based on a unique text string, like a 'find' feature. Text filters are applied by clicking the drop down menu at the top of the column you want to apply the filter to and choosing 'Text filter'.
 
-As with Facets, the Filter options appear in the left hand panel in OpenRefine. As you type the text you want to find into the Filter's text box, OpenRefine works to display only rows that contain that text in the relevant column.
+As with Facets, the Filter options appear in the left hand panel in OpenRefine. As you type the text you want to use in the Filter in the Filter's text box, OpenRefine works to display only rows that contain that text in the relevant column.
 
 You can also use [regular expressions](https://librarycarpentry.github.io/lc-data-intro/01-regular-expressions/) in the filter.
 

--- a/_episodes/04-faceting-and-filtering.md
+++ b/_episodes/04-faceting-and-filtering.md
@@ -23,7 +23,7 @@ Facets are one of the most useful features of OpenRefine and can help in both ge
 
 A 'Facet' groups all the values that appear in a column, and then allows you to filter the data by these values and edit values across many records at the same time.
 
-The simplest type of Facet is called a 'Text facet'. This groups all the text values in a column and lists each value with the number of records it appears in. The facet information always appears in the left hand panel in the OpenRefine interface.
+One of the most commonly used facets is called a 'Text facet'. This groups all the text values in a column and lists each value with the number of records it appears in. The facet information always appears in the left hand panel in the OpenRefine interface.
 
 To create a Text Facet for a column, click on the drop down menu at the top of the publisher column and choose `Facet -> Text Facet`. The facet will then appear in the left hand panel.
 

--- a/_episodes/05-clustering.md
+++ b/_episodes/05-clustering.md
@@ -26,7 +26,7 @@ The 'Clusters' are created automatically according to an algorithm. OpenRefine s
 
 For more information on the methods used to create Clusters, see [https://github.com/OpenRefine/OpenRefine/wiki/Clustering-In-Depth](https://github.com/OpenRefine/OpenRefine/wiki/Clustering-In-Depth)
 
-For each cluster, you have the option of 'merging' the values together - that is, replace the various inconsistent values with a single consistent value. By default, OpenRefine uses the most common value in the cluster as the new value, but you can select another value by clicking the value itself, or you can simply type the desired value into the 'New Cell Value' box.
+For each cluster, you have the option of 'merging' the values together - that is, replace the various inconsistent values with a single consistent value. By default, OpenRefine uses the most common value in the cluster as the new value, but you can select another value by clicking the value itself, or you can type the desired value into the 'New Cell Value' box.
 
 >## Use Clustering to clean up author data
 >

--- a/_episodes/08-writing-transformations.md
+++ b/_episodes/08-writing-transformations.md
@@ -16,7 +16,7 @@ keypoints:
 
 To start writing transformations, select the column on which you wish to perform a transformation and choose ```Edit cells->Transform…```. In the screen that displays you have a place to write a transformation (the 'Expression' box) and then the ability to Preview the effect the transformation would have on 10 rows of your data.
 
-The transformation you type into the 'Expression' box has to be a valid GREL expression. The simplest expression is simply the word 'value' by itself - which simply means the value that is currently in the column - that is: make no change.
+The transformation you type into the 'Expression' box has to be a valid GREL expression. The default expression is the word `value` by itself - which means the value that is currently in the column - that is: make no change.
 
 GREL functions are written by giving a value of some kind (a text string, a date, a number etc.) to a GREL function. Some GREL functions take additional parameters or options which control how the function works. GREL supports two types of syntax:
 

--- a/_episodes/09-undo-and-redo.md
+++ b/_episodes/09-undo-and-redo.md
@@ -12,18 +12,18 @@ keypoints:
 ---
 
 ## Undo and Redo
-OpenRefine lets you undo, and redo, any number of steps you have taken in cleaning the data. This means you can always try out transformations and 'undo' if you need to. The way OpenRefine records the steps you have taken even allows you to take the steps you've carried out on one data set, and apply it to another data set by a simple copy and paste operation.
+OpenRefine lets you undo, and redo, any number of steps you have taken in cleaning the data. This means you can always try out transformations and 'undo' if you need to. The way OpenRefine records the steps you have taken even allows you to take the steps you've carried out on one data set, and apply it to another data set by a copy and paste operation.
 
 The ```Undo``` and ```Redo``` options are accessed via the lefthand panel.
 
-The Undo/Redo panel lists all the steps you've taken so far. To undo steps, simply click on the last step you want to preserve in the list and this will automatically undo all the changes made since that step.
+The Undo/Redo panel lists all the steps you've taken so far. To undo steps, click on the last step you want to preserve in the list and this will automatically undo all the changes made since that step.
 
-The remaining steps will continue to show in the list but greyed out, and you can reapply them by simply clicking on the last step you want to apply.
+The remaining steps will continue to show in the list but greyed out, and you can reapply them by clicking on the last step you want to apply.
 
 However, if you 'undo' a set of steps and then start doing new transformations, the greyed out steps will disappear and you will no longer have the option to 'redo' these steps.
 
-If you wish to save a set of steps to be re-applied later, for instance, to a different project, you can click the ```Extract``` button. This gives you the option to select steps that you want to save, and extract the code for those steps in a format called ‘JSON’. You can copy the extracted JSON and save it as a simple text file (e.g. in Notepad).
+If you wish to save a set of steps to be re-applied later, for instance, to a different project, you can click the ```Extract``` button. This gives you the option to select steps that you want to save, and extract the code for those steps in a format called ‘JSON’. You can copy the extracted JSON and save it as a plain text file (e.g. in Notepad).
 
-To apply a set of steps you have copied or saved in this 'JSON' format use the ```Apply``` button and paste in the JSON. In this way you can share transformations between projects and each other.
+To apply a set of steps you have copied or saved in this 'JSON' format use the ```Apply``` button and paste in the JSON. In this way you can share transformations between projects and with other people.
 
 Undo/Redo data is stored with the Project and is saved automatically as you work, so next time you open the project, you can access your full history of steps you have carried out and undo/redo in exactly the same way.

--- a/_episodes/10-data-transformation.md
+++ b/_episodes/10-data-transformation.md
@@ -29,7 +29,7 @@ Understanding data types and regular expressions will help you write more comple
 {: .callout}
 
 ### Dates and Numbers
-So far we've been looking only at 'String' type data. Much of the time it is possible to treat numbers and dates as strings. For example in the Date column we have the date of publication represented as a String. However, some operations and transformations only work on 'number' or 'date' type operations, such as sorting values in numeric or date order. To carry out these functions we need to convert the values to a date or number first.
+So far we've been looking only at 'String' type data. Much of the time it is possible to treat numbers and dates as strings. For example in the Date column we have the date of publication represented as a String. However, some operations and transformations only work on 'number' or 'date' typed data, such as sorting values in numeric or date order. To carry out these functions we need to convert the values to a date or number first.
 
 >## Reformat the Date
 >1. Make sure you remove all Facets and Filters

--- a/_episodes/10-data-transformation.md
+++ b/_episodes/10-data-transformation.md
@@ -29,7 +29,7 @@ Understanding data types and regular expressions will help you write more comple
 {: .callout}
 
 ### Dates and Numbers
-So far we've been looking only at 'String' type data. Much of the time it is possible to treat numbers and dates as strings. For example in the Date column we have the date of publication represented as a String. However, some operations and transformations only work on 'number' or 'date' type operations. The simplest example is sorting values in numeric or date order. To carry out these functions we need to convert the values to a date or number first.
+So far we've been looking only at 'String' type data. Much of the time it is possible to treat numbers and dates as strings. For example in the Date column we have the date of publication represented as a String. However, some operations and transformations only work on 'number' or 'date' type operations, such as sorting values in numeric or date order. To carry out these functions we need to convert the values to a date or number first.
 
 >## Reformat the Date
 >1. Make sure you remove all Facets and Filters

--- a/_episodes/13-looking-up-data.md
+++ b/_episodes/13-looking-up-data.md
@@ -27,7 +27,7 @@ Typically this is a two step process, firstly a step to retrieve data from a rem
 
 To retrieve data from an external source, use the drop down menu at any column heading and select ‘Edit column->Add column by fetching URLs’.
 
-This will prompt you for a GREL expression to create a URL. Usually this would be a URL that uses existing values in your data to build a query. When the query runs OpenRefine will request each URL (for each line) and retrieve whatever data is returned (this may often be structured data, but could be simply HTML).
+This will prompt you for a GREL expression to create a URL. Usually this would be a URL that uses existing values in your data to build a query. When the query runs OpenRefine will request each URL (for each line) and retrieve whatever data is returned (this may often be structured data, but could be HTML).
 
 The data retrieved will be stored in a cell in the new column that has been added to the project. You can then use OpenRefine transformations to extract relevant information from the data that has been retrieved. Two specific OpenRefine functions used for this are:
 
@@ -58,7 +58,7 @@ The next exercise demonstrates this two stage process in full.
 >The syntax for requesting journal information from CrossRef is ```http://api.crossref.org/journals/{ISSN}``` where {ISSN} is replaced with the ISSN of the journal
 >
 >* In the expression box type the GREL ```"https://api.crossref.org/journals/"+value```
-> 
+>
 >At this point, your screen should be similar to this:
 >![Add column by fetching URLs screen capture](../assets/img/openrefine_add_columns_by_url.png)
 >
@@ -76,7 +76,7 @@ The next exercise demonstrates this two stage process in full.
 >* In the Expression box type the GREL ```value.parseJson().message.title```
 >* You should see in the Preview the Journal title displays
 >
->The reason for using 'Add column based on this column' is simply that this allows you to retain the full JSON and extract further data from it if you need to. If you only wanted the title and did not need any other information from the JSON you could use 'Edit cells->Transform...' with the same GREL expression.
+>The reason for using 'Add column based on this column' is that this allows you to retain the full JSON and extract further data from it if you need to. If you only wanted the title and did not need any other information from the JSON you could use 'Edit cells->Transform...' with the same GREL expression.
 {: .challenge}
 
 ## Reconciliation services
@@ -97,7 +97,7 @@ For more information on using Reconciliation services see [https://github.com/Op
 >## Reconcile Publisher names with VIAF IDs
 >In this exercise you are going to use the VIAF Reconciliation service written by [Jeff Chiu](https://twitter.com/absolutelyjeff). Jeff offers two ways of using the reconciliation service - either via a public service he runs at [http://refine.codefork.com/](http://refine.codefork.com/), or by installing and running the service locally using the instructions at [https://github.com/codeforkjeff/conciliator](https://github.com/codeforkjeff/conciliator).
 >
->If you are going to do a lot of reconciliation, please install and run your own local reconciliation service - the instructions at [https://github.com/codeforkjeff/conciliator](https://github.com/codeforkjeff/conciliator#running-conciliator-on-your-own-computer) make this reasonably straightforward.
+>If you are going to do a lot of reconciliation, please install and run your own local reconciliation service following the instructions at [https://github.com/codeforkjeff/conciliator](https://github.com/codeforkjeff/conciliator#running-conciliator-on-your-own-computer).
 >
 >Once you have chosen which service you are going to use:
 >
@@ -162,4 +162,5 @@ As it returns the whole row for each match, you can use a transformation to extr
 
 You can use this function to compare the contents of two OpenRefine projects, or to use data between the two projects.
 
-The [VIB-Bits extension](https://www.bits.vib.be/index.php/software-overview/openrefine) adds a number of very useful functions to OpenRefine including a way of using the 'cross' function with simply point-and-click functionality which makes looking up data from other projects much easier.
+The [VIB-Bits extension](https://www.bits.vib.be/index.php/software-overview/openrefine) adds a number of very useful functions to OpenRefine.
+One of them is "Add column(s) from other projects...", which provides a dialog window to help you work with the `cross` function with less typing.


### PR DESCRIPTION
To prevent instructors and learners looking at the materials from seeing and especially using words like 'just', 'simply' and the like, this removes or replaces their use in episodes 4, 5, 8, 9 and 10.
It makes a few other textual changes like 'Refine' -> 'OpenRefine' in episode 4 and changing a pair of quotes to backticks in episode 8.

Note that in episode 4, on facets and filters, I removed 'easily' from a key question and key point.

This relates to #137 (but addresses only the demotivating language). I would like to get feedback on wording, because I did more than *simply* (grin) remove the words. I can make additional changes if necessary.