### PR TITLE
Updated Episode 12 to fix misleading title and add a little more information

### DIFF
--- a/_episodes/12-export-transformation.md
+++ b/_episodes/12-export-transformation.md
@@ -1,16 +1,24 @@
 ---
-title: "Transformations - Exporting"
+title: "Exporting your revised data"
 teaching: 5
 exercises: 0
 questions:
-- "How do I export transformed data?"
+- "How do I export data from OpenRefine?"
 objectives:
 - "Explain how to export data in different formats from OpenRefine"
 keypoints:
 - "You can export your data in a variety of formats"
 ---
 
+## Note about OpenRefine
+All the edits you make to your data using OpenRefine are being stored inside the OpenRefine program and are not being saved to your original file. That's why OpenRefine uses the terms "import" and "export" to talk about moving your data in and out of the OpenRefine interface. Therefore, in order to save your work into a file format you can view in other programs or share with others, you need to export your data.
+
 ## Exporting data
 Once you have finished working with a data set in OpenRefine you may wish to export it. The export options are accessed through the ```Export``` button at the top right of the OpenRefine interface.
 
 Export formats support include HTML, Excel and comma- and tab-separated value (csv and tsv). You can also write a custom export, selecting to export specific fields, adding a header or footer and specifying the exact format.
+
+## Exporting a portion of your data
+You can also export a portion of your data by using facets or filters to select a portion of your data. With only those rows selected, you can select the export format and your resulting file will only include the select rows. 
+
+*Note well:* It's easy to export only a portion of your data by accident, so make sure you look at the top left to ensure all rows are being displayed when you want to do a full export.  


### PR DESCRIPTION
Hi,

I am submitting a pull request with a few changes to Episode 12.

1. Change title. (I think there was an issue about this topic and I will find it and link it here). The title was "Transformations - Exporting," which gives the impression that this is a continuation of the Transformations topic from Episodes 10 and 11. However, that's not accurate. The only thing discussed in the episode is how to export data from OpenRefine, and you don't need to do transformations to want to know how to export data. It's a distinct topic and activity. I think changing the title will make it easier for Instructors and Learners alike to understand the topic of the lesson.

2. I added a new paragraph at the beginning to highlight that OpenRefine doesn't "save" your work into the file that you got the data from. This characteristic is unlike a lot of software applications that are used to look at and edit data or text, so it's worth highlighting that this program works differently.

3. I added a new paragraph that discusses exporting a portion of your data by faceting and exporting when a facet is selected. 

I think this episode could be further developed, but that's all I have time for right now. And I think baby steps are okay!

I am teaching this lesson next week, and that's why I'm going over it so carefully. Thank you, maintainers, for your patience and help!

