### PR TITLE
Issue #197 culturally neutral name order language

### DIFF
--- a/_episodes/10-data-transformation.md
+++ b/_episodes/10-data-transformation.md
@@ -52,7 +52,7 @@ Such tests can be combined with other GREL expressions to create more complex tr
 
 >## Find Reversed Author Names
 >In this exercise we are going to use the Boolean data type.
->If you look at the Authors column, you can see that most of the author names are written in the natural order. However, a few have been reversed to put the family name first.
+>If you look at the Authors column, you can see that most of the author names are written with the personal name first. However, a few have been reversed to put the family name first.
 >
 >We can do a crude test for reversed author names by looking for those that contain a comma:
 >
@@ -62,5 +62,5 @@ Such tests can be combined with other GREL expressions to create more complex tr
 >4. In the Expression box type ```value.contains(",").toString()```
 >* Click ```OK```
 >* Since the 'contains' function outputs a Boolean value, you should see a facet that contains 'false' and 'true'. These represent the outcome of the expression, i.e. true = values containing a comma; false = values not containing a comma
->* In order to change the names to natural order, see the Arrays lesson.
+>* In order to change the names to personal name first order, see the Arrays lesson.
 {: .checklist}

--- a/_episodes/11-using-arrays-transformations.md
+++ b/_episodes/11-using-arrays-transformations.md
@@ -50,10 +50,10 @@ value.split(",").sort().join(",")
 Taking the above example again, this would result in a string with the days of the week in alphabetical order, listed with commas between each day.
 
 >## Reverse author names
->You may already have done the boolean exercise and have a facet containing the names in natural order. In this case, select the 'true' facet and start with the step **"1. On the ```Authors``` column use..."**
+>You may already have done the boolean exercise and have a facet containing the names in personal name first order. In this case, select the 'true' facet and start with the step **"1. On the ```Authors``` column use..."**
 >
 >In this exercise we are going to use both the Boolean and Array data types.
->If you look at the Authors column, you can see that most of the author names are written in the natural order. However, a few have been reversed to put the family name first.
+>If you look at the Authors column, you can see that most of the author names are written in personal name first order. However, a few have been reversed to put the family name first.
 >
 >We can do a crude test for reversed author names by looking for those that contain a comma:
 >
@@ -71,7 +71,7 @@ Taking the above example again, this would result in a string with the days of t
 >2. In the Expression box type ```value.match(/(.*),(.*)/)```  The ```/```,  means you are using a regular expression inside a GREL expression. The parentheses indicate you are going to match a group of characters. The ```.*``` expression will match any character(s) appearing 0, 1 or more times. So here we are matching any number of characters, a comma, and another set of any number of characters.
 >3. See how this creates an array with two members in each row in the Preview column
 >
->To get the author name in the natural order you can reverse the array and join it back together with a space to create the string you need:
+>To get the author name in personal name first order you can reverse the array and join it back together with a space to create the string you need:
 >
 >1. In the Expression box, add to the existing expression until it reads ```value.match(/(.*),(.*)/).reverse().join(" ")```
 >2. In the Preview view you should be able see this has reversed the array, and joined it back into a string


### PR DESCRIPTION
Changed lesson text to replace the terminology "natural order" with the more culturally neutral terminology "personal name first" and "family name first," and to change the terminology "reverse order" in places appropriate to go with the culturally neutral terminology. Changes are to in lesson 10-data-transformation and lesson 11-using-arrays-transformations and this pull request closes #197 . Further tweaks to this language welcome. 