### PR TITLE
Avoid LoadError in jekyll-3.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Without this, "make serve" leads to this error for me:

> bundler: failed to load command: jekyll (/Users/…/ruby/3.0.4/bin/jekyll)
> /Users/…/ruby/3.0.4/lib/ruby/gems/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)