### PR TITLE
Merge duplicate requirements details into setup

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -35,10 +35,6 @@ ____
   - Change the working directory to the OpenRefine folder at "C:\Users\JaneDoe"
   - Run openrefine.exe
 
-* If a learner is unable to install OpenRefine on their computer due to IT restrictions for example, there are cloud services available that they could try:
-  - [openrefineder](https://github.com/betatim/openrefineder/) using MyBinder [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/6ba108b?urlpath=%2Fopenrefine) (OpenRefine 3.4.1, free to use without registration, [restricted](https://mybinder.readthedocs.io/en/latest/faq.html#how-much-memory-am-i-given-when-using-binder) to 1-2 GB RAM and server will be deleted after 10 minutes of inactivity)
-
 * If "https" doesn't work to fetch CrossRef during Advanced OpenRefine Functions, they can try "http"
 
 * If they need to diagnose failure to fetch the content from the URL they can check the "Store error" option in the "Add column by fetching URLs" dialogue and try looking at the common problems listed in the [documentation](https://docs.openrefine.org/manual/columnediting#common-errors)
-

--- a/index.md
+++ b/index.md
@@ -4,15 +4,11 @@ layout: lesson
 This Library Carpentry lesson introduces people working in library- and information-related roles to working with data in OpenRefine. At the conclusion of the lesson you will understand what the OpenRefine software does and how to use the OpenRefine software to work with data files.
 
 > ## Prerequisites
-> To complete this lesson you will need to install [OpenRefine](http://openrefine.org/download.html) and download the file [doaj-article-sample.csv](https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv).
->
-> OpenRefine requires one of these web browsers:
-> * Google Chrome
-> * Chromium
-> * Opera
-> * Microsoft Edge
+> To complete this lesson you will need to:
 > 
-> OpenRefine has some issues with Firefox. Internet Explorer is not supported. 
+> 1. Install OpenRefine
+> 1. Download a data file
+> 1. Use a supported browser
 > 
-> See [Setup](https://librarycarpentry.org/lc-open-refine/setup.html) for more information.
+> See [our setup page](https://librarycarpentry.org/lc-open-refine/setup.html) for more information.
 {: .prereq}

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ This Library Carpentry lesson introduces people working in library- and informat
 > ## Prerequisites
 > To complete this lesson you will need to:
 > 
-> 1. Install OpenRefine
+> 1. Install OpenRefine or use it through a cloud service
 > 1. Download a data file
 > 1. Use a supported browser
 > 

--- a/setup.md
+++ b/setup.md
@@ -43,6 +43,16 @@ Install the default version available from your distribution. For example, on Ub
 [Microsoft Edge](https://www.microsoft.com/edge),
 [Chrome](https://www.google.com/chrome/) or [Safari](https://www.apple.com/safari/) instead.
 
+### OpenRefine cloud services
+
+If you are unable to install OpenRefine (due to IT restrictions, for example), please try
+[openrefineder using MyBinder](https://github.com/betatim/openrefineder/).
+It's free to use without registration, but it's the older OpenRefine 3.4.1,
+[restricted to 1-2 GB RAM](https://mybinder.readthedocs.io/en/latest/faq.html#how-much-memory-am-i-given-when-using-binder),
+and the server will be deleted after 10 minutes of inactivity.
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/6ba108b?urlpath=%2Fopenrefine)
+
 ### Downloading the data
 
 You can download [doaj-article-sample.csv](https://github.com/LibraryCarpentry/lc-open-refine/raw/gh-pages/data/doaj-article-sample.csv), which is a csv file that will open in a new browser tab. Be sure to right click or control click in order to save the file (NOTE: In Safari, right click and select **download linked file**; in Chrome and Firefox, right click and select **save link as...**). Make a note of the location (i.e. the folder, your desktop) to which you save the file.

--- a/setup.md
+++ b/setup.md
@@ -39,9 +39,9 @@ to download an installer package. Please note that
 JRE or JDK installed on your system, most distribution repositories will contain OpenJRE / OpenJDK packages. 
 Install the default version available from your distribution. For example, on Ubuntu/Debian: 
 `sudo apt install default-jre`.
-* OpenRefine does not support Internet Explorer. Please use [Firefox](https://www.mozilla.org/firefox/new/), 
+* OpenRefine does not support Internet Explorer. Please use [Firefox](https://www.mozilla.org/firefox/new/),
+[Microsoft Edge](https://www.microsoft.com/edge),
 [Chrome](https://www.google.com/chrome/) or [Safari](https://www.apple.com/safari/) instead.
-
 
 ### Downloading the data
 


### PR DESCRIPTION
Follow-up from the earlier review discussions: https://github.com/LibraryCarpentry/lc-open-refine/pull/242/files#r961365325 & https://github.com/LibraryCarpentry/lc-open-refine/pull/242/files#r961369747.

In order to highlight the setup page, this PR:

1. Moves the cloud service section to it
2. Summarises the setup steps in the requirements callout