### PR TITLE
New option for saving operation history

### DIFF
--- a/_episodes/09-undo-and-redo.md
+++ b/_episodes/09-undo-and-redo.md
@@ -22,7 +22,7 @@ The remaining steps will continue to show in the list but greyed out, and you ca
 
 However, if you 'undo' a set of steps and then start doing new transformations, the greyed out steps will disappear and you will no longer have the option to 'redo' these steps.
 
-If you wish to save a set of steps to be re-applied later, for instance, to a different project, you can click the ```Extract``` button. This gives you the option to select steps that you want to save, and extract the code for those steps in a format called ‘JSON’. You can copy the extracted JSON and save it as a plain text file (e.g. in Notepad).
+If you wish to save a set of steps to be re-applied later, for instance, to a different project, you can click the ```Extract``` button. This gives you the option to select steps that you want to save, and extract the code for those steps in a format called ‘JSON’. You can copy the extracted JSON and save it as a plain text file (e.g. in Notepad). If you are using OpenRefine version 3.6.0 or later, you can also click the ```Export``` button in the "Extract operation history" window to open a save dialog and directly save the JSON instead of first copying it to a text file.
 
 To apply a set of steps you have copied or saved in this 'JSON' format use the ```Apply``` button and paste in the JSON. In this way you can share transformations between projects and with other people.
 


### PR DESCRIPTION
This may be easier for participants than the previous copy-and-paste process.
