### PR TITLE
Typo in line 83

### DIFF
--- a/_episodes/03-working-with-data.md
+++ b/_episodes/03-working-with-data.md
@@ -80,7 +80,7 @@ Records values will now be the same since we do not have any more columns with s
 The value that separates multi-valued cells is called a separator or delimiter. Choosing a good
 separator is important. In the examples, we've seen the pipe character ( \| ) has been used.
 
-Choosing the wrong separator can lead to problems. Consider the following multi-valued Author example.
+Choosing the wrong separator can lead to problems. Consider the following multi-valued Author example,
 with a pipe as a separator.
 ```
 Jones, Andrew | Davis, S.


### PR DESCRIPTION
On line 83 change the full stop(.) after the word "example" to a comma(,).


