### PR TITLE
Replace broken link to old setup page in prerequisites

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,9 +14,7 @@ To complete this lesson you will need to:
 2. Download a data file
 3. Use a supported browser
 
-See [our setup page](https://librarycarpentry.org/lc-open-refine/setup.html) for more information.
-
+See below for more information.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
-
 


### PR DESCRIPTION
The setup instructions are now on the same page, so I replaced the link with "below".