### PR TITLE
Link to relative URLs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Lesson Maintainers communication is via the [team site](https://github.com/orgs/
 ## License
 
 All Software, Data, and Library Carpentry instructional material is made available under the [Creative Commons Attribution
-license](https://github.com/LibraryCarpentry/lc-open-refine/blob/gh-pages/LICENSE.md).
+license](LICENSE.md).
 
 ## Contributing
 
-There are many ways to discuss and contribute to Library Carpentry lessons. Visit the lesson [discussion page](https://librarycarpentry.org/lc-open-refine/discuss/index.html) to learn more. Also see [Contributing](https://github.com/LibraryCarpentry/lc-open-refine/blob/gh-pages/CONTRIBUTING.md).
+There are many ways to discuss and contribute to Library Carpentry lessons. Visit the lesson [discussion page](https://librarycarpentry.org/lc-open-refine/discuss/index.html) to learn more. Also see [Contributing](CONTRIBUTING.md).
 
 ## Code of Conduct
 


### PR DESCRIPTION
Closes #312 by using relative links. These work in cloned repositories as well as on GitHub.