### PR TITLE
Restore http link

### DIFF
--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -14,7 +14,7 @@ Adapt/print from:
 
 - [Library Carpentry Reference Page](https://librarycarpentry.org/lc-open-refine/reference.html)
 - [Instructor Draft Notes](https://github.com/LibraryCarpentry/lc-open-refine/blob/gh-pages/files/draft-instructor-notes.md)
-- [Introduction to OpenRefine by Owen Stephens](https://www.meanboyfriend.com/overdue_ideas/wp-content/uploads/2014/11/Introduction-to-OpenRefine-handout-CC-BY.pdf)
+- [Introduction to OpenRefine by Owen Stephens](http://www.meanboyfriend.com/overdue_ideas/wp-content/uploads/2014/11/Introduction-to-OpenRefine-handout-CC-BY.pdf)
 
 ***
 


### PR DESCRIPTION
Closes #325 
An http link had been incorrectly changed to https. This corrects the protocol so the link works.
